### PR TITLE
Switch the order of checks in node_ptr

### DIFF
--- a/deepmesa-lists/src/linkedlist/list.rs
+++ b/deepmesa-lists/src/linkedlist/list.rs
@@ -1742,10 +1742,13 @@ impl<T> FastLinkedList<T> {
             return None;
         }
         unsafe {
-            if (*node.ptr).nid != node.nid {
+            // First check if this node is on the freelist. If it is
+            // then we don't need to check the node id (nid)
+            if (*node.ptr).fl_node {
                 return None;
             }
-            if (*node.ptr).fl_node {
+
+            if (*node.ptr).nid != node.nid {
                 return None;
             }
         }


### PR DESCRIPTION
First check if this node is on the freelist. If it is then we don't
need to check the node id (nid). Some significant percentage of the
time the node will be on the freelist and if it is we can return None
without checking the nodeId (nid) which is a bit faster. Given that
node_ptr is called on almost every method its helpful to make it as
efficient as possible.